### PR TITLE
feat: get queue length and concurrency through arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,23 @@ Copy `.env.example` to `.env` and fill the environment variables based on the Mu
 
 All of the videos from `videos.json` will be uploaded directly to Mux without saving them to the disk.
 
-This process is kinda slow but, if you have a good internet connection and hardware, you can increment the concurrency inside `src/lib/queue.ts` to migrate more videos in parallel.
+This process is kinda slow but, if you have a good internet connection and hardware, you can increment the concurrency passing as argv argument to migrate more videos in parallel, following the example below.
+
+```sh
+$ yarn run-migration 3
+```
 
 ## Getting the Playback ID list
 
 If you're not using signed URLs, you'll need the playback ID to play the videos.
 
-1. Open up the file `src/GetPlaybackIds.ts`;
-2. At line 18 you'll be able to change the page every time you run this script (for now you have to manually set the page number so if you have 850 assets you'll have to run this script 9 times);
-3. Run `yarn get-playback-ids` or `npm run get-playback-ids`;
+The mux assets list are paginated so you'll need to provide the number of the assets you want to reach.
+
+```sh
+# if you want to get 500 videos playbacks id
+
+$ yarn get-playback-ids 500
+```
 
 The script will fill the `data/export.csv` file with the data including the original video ID from `data/videos.json`, the playback ID e the duration.
 

--- a/src/lib/queue.ts
+++ b/src/lib/queue.ts
@@ -1,14 +1,17 @@
 import fastq, { queueAsPromised } from "fastq"
 import { worker } from './worker'
 
+const DEFAULT_CONCURRENCY = 1
+
+const CONCURRENCY = Number(process.argv[2]) || DEFAULT_CONCURRENCY
+
+const isConcurrencyInvalid = isNaN(CONCURRENCY)
+
+if (isConcurrencyInvalid && CONCURRENCY) throw new Error('Queue concurrency must be a number')
+
 export type QueueTask = {
   videoId: string;
   url: string;
 }
-
-/**
- * How many videos will be processed in parallel.
- */
-const CONCURRENCY = 1;
 
 export const queue: queueAsPromised<QueueTask> = fastq.promise(worker, CONCURRENCY)


### PR DESCRIPTION
My wish was make this functionality a _cli_ but it seems to be more powerful than it needed so I just made some improvements